### PR TITLE
Added probability sampling based on TraceId #1

### DIFF
--- a/sdk/Trace/Sampler/TraceIdRatioBasedSampler.php
+++ b/sdk/Trace/Sampler/TraceIdRatioBasedSampler.php
@@ -29,6 +29,9 @@ class TraceIdRatioBasedSampler implements Sampler
      */
     public function __construct(float $probability)
     {
+        if ($probability < 0.0 or $probability > 0.0) {
+            throw new InvalidArgumentException("probability should be be between 0.0 and 1.0.");
+        }
         $this->probability = $probability;
     }
 
@@ -50,7 +53,12 @@ class TraceIdRatioBasedSampler implements Sampler
         }
 
         // TODO: implement as a function of TraceID when specification is ready
-        $decision = (lcg_value() < $this->probability)
+        /**
+         * For compatibility with 64 bit IDs, the sampler checks the 64 first bits of the trace ID to decide whether to sample
+         */
+        $traceIdLimit = (1 << 64) - 1;
+        $traceIdLowerBytes = ($traceId[0]<<56) + ($traceId[1]<<48) + ($traceId[2]<<40) + ($traceId[3]<<32) + ($traceId[4]<<24) + ($traceId[5]<<16) + ($traceId[6]<<8) + $traceId[7]; 
+        $decision = ($traceIdLowerBytes < $probability * tradeIdLimit)
             ? SamplingResult::RECORD_AND_SAMPLED
             : SamplingResult::NOT_RECORD;
 

--- a/tests/Sdk/Integration/TraceIdRatioBasedSamplerTest.php
+++ b/tests/Sdk/Integration/TraceIdRatioBasedSamplerTest.php
@@ -37,6 +37,32 @@ class TraceIdRatioBasedSamplerTest extends TestCase
         $this->assertEquals(SamplingResult::RECORD_AND_SAMPLED, $decision->getDecision());
     }
 
+    public function testFailingTraceIdRatioBasedSamplerDecision()
+    {
+        $sampler = new TraceIdRatioBasedSampler(0.99);
+        $decision = $sampler->shouldSample(
+            null,
+            '4bf92f3577b34da6afffffffffffffff',
+            '00f067aa0ba902b7',
+            'test.opentelemetry.io',
+            API\SpanKind::KIND_INTERNAL
+        );
+        $this->assertEquals(SamplingResult::NOT_RECORD, $decision->getDecision());
+    }
+
+    public function testPassingTraceIdRatioBasedSamplerDecision()
+    {
+        $sampler = new TraceIdRatioBasedSampler(0.01);
+        $decision = $sampler->shouldSample(
+            null,
+            '4bf92f3577b34da6a000000000000000',
+            '00f067aa0ba902b7',
+            'test.opentelemetry.io',
+            API\SpanKind::KIND_INTERNAL
+        );
+        $this->assertEquals(SamplingResult::RECORD_AND_SAMPLED, $decision->getDecision());
+    }
+
     public function testAlwaysOnSamplerDescription()
     {
         $sampler = new TraceIdRatioBasedSampler(0.0001);


### PR DESCRIPTION
This pull request hopes to resolve this issue: open-telemetry#86 which requires implementation of the ShouldSample function in the TraceIdRatioBasedSampler as described in these specs: https://github.com/open-telemetry/opentelemetry-specification/blob/e0bd41739a92304c0be5d68840f434e281b5f8b2/specification/trace/sdk.md#shouldsample.