### PR TITLE
Fixed idgenerator issues in SpanOptions and Tracer

### DIFF
--- a/sdk/Trace/SpanOptions.php
+++ b/sdk/Trace/SpanOptions.php
@@ -98,7 +98,7 @@ final class SpanOptions implements API\SpanOptions
         $span = $this->tracer->getActiveSpan();
         $context = $span->getContext()->isValid()
             ? SpanContext::fork($span->getContext()->getTraceId())
-            : SpanContext::generate();
+            : SpanContext::fork($this->tracer->getTracerProvider()->getIdGenerator()->generateTraceId());
 
         $span = new Span($this->name, $context, $this->parent, null, $this->tracer->getResource(), $this->kind, $this->spanProcessor);
 

--- a/sdk/Trace/Tracer.php
+++ b/sdk/Trace/Tracer.php
@@ -119,7 +119,7 @@ class Tracer implements API\Tracer
         $parentContextIsNoopSpan = !$parentContext->isValid();
 
         if ($parentContextIsNoopSpan) {
-            $parentContext = $this->importedContext ?? SpanContext::generate(true);
+            $parentContext = $this->importedContext ?? SpanContext::fork($this->provider->getIdGenerator()->generateTraceId(), true);
         }
 
         /*
@@ -230,6 +230,11 @@ class Tracer implements API\Tracer
     public function getResource(): ResourceInfo
     {
         return clone $this->resource;
+    }
+
+    public function getTracerProvider(): TracerProvider
+    {
+        return $this->provider;
     }
 
     private function generateSpanInstance(string $name, API\SpanContext $context, API\SpanContext $parentContext = null, Sampler $sampler = null, ResourceInfo $resource = null, int $spanKind = API\SpanKind::KIND_INTERNAL): API\Span


### PR DESCRIPTION
This fixes issue # 377

A getter was created to make available the `TracerProvider` from a given Tracer object so that the `IdGenerator` can be reached to generate ids

The changed lines now generate ids according to the provided `IdGenerator`